### PR TITLE
feat: complete ToDiagnosticMessageName migration for Diagnostic.Create

### DIFF
--- a/src/analysis/Analyzers/ArgumentAnalyzer.cs
+++ b/src/analysis/Analyzers/ArgumentAnalyzer.cs
@@ -281,7 +281,7 @@ namespace SatorImaging.StaticMemberAnalyzer.Analysis.Analyzers
             context.ReportDiagnostic(Diagnostic.Create(
                 Rule_LiteralArgument,
                 argOp.Syntax.GetLocation(),
-                argOp.Parameter?.Name ?? UnknownParameterName));
+                argOp.Parameter?.ToDiagnosticMessageName() ?? UnknownParameterName));
         }
 
         private static bool TryUnwrapConversion(IOperation operation, out IOperation unwrapped)

--- a/src/analysis/Analyzers/UnderliningAnalyzer.cs
+++ b/src/analysis/Analyzers/UnderliningAnalyzer.cs
@@ -762,7 +762,7 @@ namespace SatorImaging.StaticMemberAnalyzer.Analysis.Analyzers
             PREFIX_SYMBOL.AsSpan().CopyTo(span);
             assem.AsSpan().CopyTo(span.Slice(PREFIX_SYMBOL.Length));
 
-            var targetName = targetSymbol.Name;
+            var targetName = targetSymbol.ToDiagnosticMessageName();
             Span<char> quoted = stackalloc char[targetName.Length + 2];
             quoted[0] = '\'';
             targetName.AsSpan().CopyTo(quoted.Slice(1));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the migration started in #354 to use `ToDiagnosticMessageName()` instead of `ISymbol.Name` for diagnostic message arguments.

## Changes

- **ArgumentAnalyzer**: `AnalyzeArgument` now passes `argOp.Parameter?.ToDiagnosticMessageName()` into `Diagnostic.Create` (the last remaining `.Name` usage in a `Diagnostic.Create` call site).
- **UnderliningAnalyzer**: `GetMessageFormatArgs` now quotes `targetSymbol.ToDiagnosticMessageName()` for underline diagnostics, so generic types display with type parameters consistently.

## Notes

- No analyzer logic changes; only diagnostic message formatting.
- Most analyzers were already migrated in #350 / #354.
- Existing analyzer tests should remain valid (parameter names are unchanged; generic-type expectations were already updated in #354).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19f0d473-aba6-4046-87f4-34e6830fcf30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19f0d473-aba6-4046-87f4-34e6830fcf30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

