### PR TITLE
fix: complete ToDiagnosticMessageName coverage in Diagnostic.Create call sites

### DIFF
--- a/src/analysis/Analyzers/LambdaAnalyzer.cs
+++ b/src/analysis/Analyzers/LambdaAnalyzer.cs
@@ -151,7 +151,7 @@ namespace SatorImaging.StaticMemberAnalyzer.Analysis.Analyzers
                 }
             }
 
-            context.ReportDiagnostic(Diagnostic.Create(Rule_InefficientDelegateDeclaration, operand.Syntax.GetLocation(), op.Type.ToDisplayString()));
+            context.ReportDiagnostic(Diagnostic.Create(Rule_InefficientDelegateDeclaration, operand.Syntax.GetLocation(), op.Type.ToDiagnosticMessageName()));
         }
 
         private static bool IsEffectivelyStatic(LambdaExpressionSyntax lambda, SemanticModel semanticModel)

--- a/src/analysis/Analyzers/StructAnalyzer.cs
+++ b/src/analysis/Analyzers/StructAnalyzer.cs
@@ -178,8 +178,8 @@ namespace SatorImaging.StaticMemberAnalyzer.Analysis.Analyzers
 
                 context.ReportDiagnostic(Diagnostic.Create(
                     Rule_ImplicitBoxing, op.Syntax.GetLocation(),
-                    op.Operand.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                    op.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
+                    op.Operand.Type.ToDiagnosticMessageName(),
+                    op.Type.ToDiagnosticMessageName()));
             }
         }
     }

--- a/src/analysis/Analyzers/TSelfTypeParameterAnalyzer.cs
+++ b/src/analysis/Analyzers/TSelfTypeParameterAnalyzer.cs
@@ -239,7 +239,7 @@ namespace SatorImaging.StaticMemberAnalyzer.Analysis.Analyzers
                         if (!isOmittableBaseType)
                         {
                             context.ReportDiagnostic(Diagnostic.Create(
-                                Rule_TSelfCovariant, foundTypeArgNode.GetLocation(), targetTypeSymbol.ToString()));
+                                Rule_TSelfCovariant, foundTypeArgNode.GetLocation(), targetTypeSymbol.ToDiagnosticMessageName()));
                         }
                     }
 
@@ -263,7 +263,7 @@ namespace SatorImaging.StaticMemberAnalyzer.Analysis.Analyzers
                         if (!isFound)
                         {
                             context.ReportDiagnostic(Diagnostic.Create(
-                                Rule_TSelfContravariant, foundTypeArgNode.GetLocation(), targetTypeSymbol.ToString()));
+                                Rule_TSelfContravariant, foundTypeArgNode.GetLocation(), targetTypeSymbol.ToDiagnosticMessageName()));
                         }
                     }
 
@@ -271,7 +271,7 @@ namespace SatorImaging.StaticMemberAnalyzer.Analysis.Analyzers
                     else
                     {
                         context.ReportDiagnostic(Diagnostic.Create(
-                            Rule_TSelfInvariant, foundTypeArgNode.GetLocation(), targetTypeSymbol.ToString()));
+                            Rule_TSelfInvariant, foundTypeArgNode.GetLocation(), targetTypeSymbol.ToDiagnosticMessageName()));
                     }
                 }
             }
@@ -319,7 +319,7 @@ namespace SatorImaging.StaticMemberAnalyzer.Analysis.Analyzers
             if (!found)
             {
                 context.ReportDiagnostic(Diagnostic.Create(Rule_TSelfPointingOther,
-                    typeConstStx.GetLocation(), expectedSymbol));
+                    typeConstStx.GetLocation(), expectedSymbol!.ToDiagnosticMessageName()));
             }
         }
 

--- a/test/AnalyzerTests/FixAllTest_SMA7001_LambdaStaticCodeFixProvider.cs
+++ b/test/AnalyzerTests/FixAllTest_SMA7001_LambdaStaticCodeFixProvider.cs
@@ -84,9 +84,9 @@ namespace Test_{0}
 
             for (int i = 0; i < 3; i++)
             {
-                test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration).WithLocation(markupKey: i * 3 + 0).WithArguments("System.Action"));
-                test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration).WithLocation(markupKey: i * 3 + 1).WithArguments("System.Action"));
-                test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration).WithLocation(markupKey: i * 3 + 2).WithArguments("System.Action"));
+                test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration).WithLocation(markupKey: i * 3 + 0).WithArguments("Action"));
+                test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration).WithLocation(markupKey: i * 3 + 1).WithArguments("Action"));
+                test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration).WithLocation(markupKey: i * 3 + 2).WithArguments("Action"));
             }
 
             // TODO: FixAllProvider test cannot be done with current Roslyn version (3.8.0).

--- a/test/AnalyzerTests/SMA0010_TSelfTypeParameterAnalyzerTests.cs
+++ b/test/AnalyzerTests/SMA0010_TSelfTypeParameterAnalyzerTests.cs
@@ -21,7 +21,7 @@ namespace Test
     public class MyValue : IValue<{|#0:object|}> { }
 }
 ";
-            var expected = VerifyCS.Diagnostic(TSelfTypeParameterAnalyzer.RuleId_TSelfInvariant).WithLocation(markupKey: 0).WithArguments("Test.MyValue");
+            var expected = VerifyCS.Diagnostic(TSelfTypeParameterAnalyzer.RuleId_TSelfInvariant).WithLocation(markupKey: 0).WithArguments("MyValue");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -54,7 +54,7 @@ namespace Test
     }
 }
 ";
-            var expected = VerifyCS.Diagnostic(TSelfTypeParameterAnalyzer.RuleId_TSelfInvariant).WithLocation(markupKey: 0).WithArguments("Test.Outer<T>.Nested");
+            var expected = VerifyCS.Diagnostic(TSelfTypeParameterAnalyzer.RuleId_TSelfInvariant).WithLocation(markupKey: 0).WithArguments("Outer<T>.Nested");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
     }

--- a/test/AnalyzerTests/SMA0011_TSelfTypeParameterAnalyzerTests.cs
+++ b/test/AnalyzerTests/SMA0011_TSelfTypeParameterAnalyzerTests.cs
@@ -24,7 +24,7 @@ namespace Test
     public class MyValue1 : MyValue0, IValue<{|#0:MyValueOther|}> { }
 }
 ";
-            var expected = VerifyCS.Diagnostic(TSelfTypeParameterAnalyzer.RuleId_TSelfCovariant).WithLocation(markupKey: 0).WithArguments("Test.MyValue1");
+            var expected = VerifyCS.Diagnostic(TSelfTypeParameterAnalyzer.RuleId_TSelfCovariant).WithLocation(markupKey: 0).WithArguments("MyValue1");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 

--- a/test/AnalyzerTests/SMA0012_TSelfTypeParameterAnalyzerTests.cs
+++ b/test/AnalyzerTests/SMA0012_TSelfTypeParameterAnalyzerTests.cs
@@ -24,7 +24,7 @@ namespace Test
     public class MyClass : MyValue1, IValue<{|#0:MyValue0|}> { }
 }
 ";
-            var expected = VerifyCS.Diagnostic(TSelfTypeParameterAnalyzer.RuleId_TSelfContravariant).WithLocation(markupKey: 0).WithArguments("Test.MyClass");
+            var expected = VerifyCS.Diagnostic(TSelfTypeParameterAnalyzer.RuleId_TSelfContravariant).WithLocation(markupKey: 0).WithArguments("MyClass");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 

--- a/test/AnalyzerTests/SMA0015_TSelfTypeParameterAnalyzerTests.cs
+++ b/test/AnalyzerTests/SMA0015_TSelfTypeParameterAnalyzerTests.cs
@@ -19,7 +19,7 @@ namespace Test
     public class MyClass<TSelf> {|#0:where TSelf : SomeOtherClass|} { }
 }
 ";
-            var expected = VerifyCS.Diagnostic(TSelfTypeParameterAnalyzer.RuleId_TSelfPointingOther).WithLocation(markupKey: 0).WithArguments("Test.MyClass<TSelf>");
+            var expected = VerifyCS.Diagnostic(TSelfTypeParameterAnalyzer.RuleId_TSelfPointingOther).WithLocation(markupKey: 0).WithArguments("MyClass<TSelf>");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 

--- a/test/AnalyzerTests/SMA7001_LambdaAnalyzerTests.cs
+++ b/test/AnalyzerTests/SMA7001_LambdaAnalyzerTests.cs
@@ -31,10 +31,10 @@ public class C
 ";
             var expected0 = VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration)
                 .WithLocation(markupKey: 0)
-                .WithArguments("System.Action");
+                .WithArguments("Action");
             var expected1 = VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration)
                 .WithLocation(markupKey: 1)
-                .WithArguments("System.Action");
+                .WithArguments("Action");
             await VerifyCS.VerifyAnalyzerAsync(test, expected0, expected1);
         }
 
@@ -56,7 +56,7 @@ public class C
 ";
             var expected = VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration)
                 .WithLocation(markupKey: 0)
-                .WithArguments("System.Action");
+                .WithArguments("Action");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -76,7 +76,7 @@ public class C
 ";
             var expected = VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration)
                 .WithLocation(markupKey: 0)
-                .WithArguments("System.Action<int>");
+                .WithArguments("Action<int>");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -96,7 +96,7 @@ public class C
 ";
             var expected = VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration)
                 .WithLocation(markupKey: 0)
-                .WithArguments("System.Func<int>");
+                .WithArguments("Func<int>");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -138,7 +138,7 @@ public class C
 ";
             var expected = VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration)
                 .WithLocation(markupKey: 0)
-                .WithArguments("System.Action<string>");
+                .WithArguments("Action<string>");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -191,7 +191,7 @@ public class C
 ";
             var expected = VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration)
                 .WithLocation(markupKey: 0)
-                .WithArguments("System.Action");
+                .WithArguments("Action");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -211,7 +211,7 @@ public class C
 ";
             var expected = VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration)
                 .WithLocation(markupKey: 0)
-                .WithArguments("System.Func<int>");
+                .WithArguments("Func<int>");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -268,7 +268,7 @@ public class C
 ";
             var expected = VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration)
                 .WithLocation(markupKey: 0)
-                .WithArguments("System.Action");
+                .WithArguments("Action");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -289,7 +289,7 @@ public class C
 ";
             var expected = VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration)
                 .WithLocation(markupKey: 0)
-                .WithArguments("System.Action");
+                .WithArguments("Action");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 

--- a/test/AnalyzerTests/SMA7001_LambdaAnalyzerTests_ImplicitConversion.cs
+++ b/test/AnalyzerTests/SMA7001_LambdaAnalyzerTests_ImplicitConversion.cs
@@ -86,7 +86,7 @@ public class Derived : Base
 ";
             var expected = VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration)
                 .WithLocation(markupKey: 0)
-                .WithArguments("System.Action");
+                .WithArguments("Action");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -106,7 +106,7 @@ public class C
 ";
             var expected = VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration)
                 .WithLocation(markupKey: 0)
-                .WithArguments("System.Action");
+                .WithArguments("Action");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -146,7 +146,7 @@ public class C
 ";
             var expected = VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration)
                 .WithLocation(markupKey: 0)
-                .WithArguments("System.Action<string>");
+                .WithArguments("Action<string>");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 

--- a/test/AnalyzerTests/SMA7001_LambdaStaticCodeFixProviderTests.cs
+++ b/test/AnalyzerTests/SMA7001_LambdaStaticCodeFixProviderTests.cs
@@ -40,7 +40,7 @@ public class C
 ";
             var expected = VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration)
                 .WithLocation(markupKey: 0)
-                .WithArguments("System.Action<int, string>");
+                .WithArguments("Action<int, string>");
             await VerifyCS.VerifyCodeFixAsync(test, expected, fixtest);
         }
 
@@ -71,7 +71,7 @@ public class C
 ";
             var expected = VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration)
                 .WithLocation(markupKey: 0)
-                .WithArguments("System.Action<int, string, bool>");
+                .WithArguments("Action<int, string, bool>");
             await VerifyCS.VerifyCodeFixAsync(test, expected, fixtest);
         }
 
@@ -91,7 +91,7 @@ public class C
 ";
             var expected = VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration)
                 .WithLocation(markupKey: 0)
-                .WithArguments("System.Action");
+                .WithArguments("Action");
             // VerifyCodeFixAsync checks that NO code fix is available if fixtest is null or same as test (depending on verifier implementation)
             // CSharpCodeFixVerifier usually checks if any fix was offered.
             await VerifyCS.VerifyCodeFixAsync(test, expected, test);
@@ -113,7 +113,7 @@ public class C
 ";
             var expected = VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration)
                 .WithLocation(markupKey: 0)
-                .WithArguments("System.Action");
+                .WithArguments("Action");
             await VerifyCS.VerifyCodeFixAsync(test, expected, test);
         }
 
@@ -146,7 +146,7 @@ public class C
 ";
             var expected = VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration)
                 .WithLocation(markupKey: 0)
-                .WithArguments("System.Action");
+                .WithArguments("Action");
             await VerifyCS.VerifyCodeFixAsync(test, expected, fixtest);
         }
 
@@ -179,7 +179,7 @@ public class C
 ";
             var expected = VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration)
                 .WithLocation(markupKey: 0)
-                .WithArguments("System.Action<int, int>");
+                .WithArguments("Action<int, int>");
             await VerifyCS.VerifyCodeFixAsync(test, expected, fixtest);
         }
 
@@ -210,7 +210,7 @@ public class C
 ";
             var expected = VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration)
                 .WithLocation(markupKey: 0)
-                .WithArguments("System.Action<int>");
+                .WithArguments("Action<int>");
             await VerifyCS.VerifyCodeFixAsync(test, expected, fixtest);
         }
 
@@ -241,7 +241,7 @@ public class C
 ";
             var expected = VerifyCS.Diagnostic(LambdaAnalyzer.RuleId_InefficientDelegateDeclaration)
                 .WithLocation(markupKey: 0)
-                .WithArguments("System.Action");
+                .WithArguments("Action");
             await VerifyCS.VerifyCodeFixAsync(test, expected, fixtest);
         }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
> **Closed in favor of the replacement PR on `cursor/diagnostic-message-name-pr-9a4c`.**
>
> **Publisher:** [**cursoragent**](https://github.com/cursoragent) (Cursor Cloud Agent) · `cursoragent@cursor.com`

This PR is superseded; please use the newer PR for review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c24fa5e4-e418-4a12-8f44-7591eb9f9a4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c24fa5e4-e418-4a12-8f44-7591eb9f9a4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

