### PR TITLE
Include outer type in nested type diagnostic names

### DIFF
--- a/src/analysis/Core.cs
+++ b/src/analysis/Core.cs
@@ -282,7 +282,7 @@ namespace SatorImaging.StaticMemberAnalyzer.Analysis
 
         static readonly SymbolDisplayFormat s_diagnosticMessageFormat = new SymbolDisplayFormat(
             globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted,
-            typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameOnly,
+            typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypes,
             genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
             memberOptions: SymbolDisplayMemberOptions.None,
             delegateStyle: SymbolDisplayDelegateStyle.NameOnly,

--- a/test/AnalyzerTests/SMA0030_StructAnalyzerTests.cs
+++ b/test/AnalyzerTests/SMA0030_StructAnalyzerTests.cs
@@ -136,7 +136,7 @@ namespace Test
 
             var expected = VerifyCS.Diagnostic(StructAnalyzer.RuleId_InvalidStructCtor)
                 .WithLocation(markupKey: 0)
-                .WithArguments("NestedStruct");
+                .WithArguments("Outer.NestedStruct");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 

--- a/test/AnalyzerTests/SMA0031_StructAnalyzerTests.cs
+++ b/test/AnalyzerTests/SMA0031_StructAnalyzerTests.cs
@@ -84,7 +84,7 @@ namespace Test
 
             var expected = VerifyCS.Diagnostic(StructAnalyzer.RuleId_InvalidReadOnlyField)
                 .WithLocation(markupKey: 0)
-                .WithArguments("NestedStruct");
+                .WithArguments("Outer.NestedStruct");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 

--- a/test/AnalyzerTests/SMA0040_DisposableAnalyzerTests.cs
+++ b/test/AnalyzerTests/SMA0040_DisposableAnalyzerTests.cs
@@ -151,7 +151,7 @@ namespace Test
 
             var expected = VerifyCS.Diagnostic(DisposableAnalyzer.RuleId_MissingUsing)
                 .WithLocation(markupKey: 0)
-                .WithArguments("NestedDisposable");
+                .WithArguments("Outer.NestedDisposable");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 

--- a/test/CoreTest.cs
+++ b/test/CoreTest.cs
@@ -569,6 +569,28 @@ class C {
         // ===== ToDiagnosticMessageName =====
 
         [TestMethod]
+        public void ToDiagnosticMessageName_Local_ReturnsSimpleName()
+        {
+            var comp = CreateCompilation("class C { void M() { int foo; } }");
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var localDecl = FindFirst<LocalDeclarationStatementSyntax>(tree.GetRoot());
+            var local = model.GetDeclaredSymbol(localDecl.Declaration.Variables[0])!;
+            Assert.AreEqual("foo", Core.ToDiagnosticMessageName(local));
+        }
+
+        [TestMethod]
+        public void ToDiagnosticMessageName_Parameter_ReturnsSimpleName()
+        {
+            var comp = CreateCompilation("class C { void M(params int[] values) { } }");
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var method = FindFirst<MethodDeclarationSyntax>(tree.GetRoot());
+            var methodSymbol = model.GetDeclaredSymbol(method)!;
+            Assert.AreEqual("values", Core.ToDiagnosticMessageName(methodSymbol.Parameters[0]));
+        }
+
+        [TestMethod]
         public void ToDiagnosticMessageName_NonGenericType_ReturnsSimpleName()
         {
             var comp = CreateCompilation("class MyClass {} class C { MyClass x; }");
@@ -586,6 +608,67 @@ class C {
             var field = FindFirst<FieldDeclarationSyntax>(comp.SyntaxTrees[0].GetRoot());
             var type = model.GetTypeInfo(field.Declaration.Type).Type!;
             Assert.AreEqual("List<int>", Core.ToDiagnosticMessageName(type));
+        }
+
+        [TestMethod]
+        public void ToDiagnosticMessageName_GenericStructType_ReturnsNameWithTypeParameters()
+        {
+            var comp = CreateCompilation("struct MyStruct<T> {} class C { MyStruct<int> x; }");
+            var model = comp.GetSemanticModel(comp.SyntaxTrees[0]);
+            var field = FindFirst<FieldDeclarationSyntax>(comp.SyntaxTrees[0].GetRoot());
+            var type = model.GetTypeInfo(field.Declaration.Type).Type!;
+            Assert.AreEqual("MyStruct<int>", Core.ToDiagnosticMessageName(type));
+        }
+
+        [TestMethod]
+        public void ToDiagnosticMessageName_NestedGenericType_IncludesOuterTypeWithoutNamespace()
+        {
+            var comp = CreateCompilation(@"
+namespace MyNamespace {
+    class Outer<T> {
+        class Inner<U> {
+            Inner<U> _field;
+        }
+    }
+}");
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var field = FindFirst<FieldDeclarationSyntax>(tree.GetRoot());
+            var type = model.GetTypeInfo(field.Declaration.Type).Type!;
+            Assert.AreEqual("Outer<T>.Inner<U>", Core.ToDiagnosticMessageName(type));
+        }
+
+        [TestMethod]
+        public void ToDiagnosticMessageName_Field_ReturnsSimpleName()
+        {
+            var comp = CreateCompilation("class C { int _field; }");
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var field = FindFirst<FieldDeclarationSyntax>(tree.GetRoot());
+            var fieldSymbol = model.GetDeclaredSymbol(field.Declaration.Variables[0])!;
+            Assert.AreEqual("_field", Core.ToDiagnosticMessageName(fieldSymbol));
+        }
+
+        [TestMethod]
+        public void ToDiagnosticMessageName_Method_ReturnsNameWithTypeParameters()
+        {
+            var comp = CreateCompilation("class C { void Foo<T>(int value) { } }");
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var method = FindFirst<MethodDeclarationSyntax>(tree.GetRoot());
+            var methodSymbol = model.GetDeclaredSymbol(method)!;
+            Assert.AreEqual("Foo<T>", Core.ToDiagnosticMessageName(methodSymbol));
+        }
+
+        [TestMethod]
+        public void ToDiagnosticMessageName_Property_ReturnsSimpleName()
+        {
+            var comp = CreateCompilation("class C { float Bar { get; set; } }");
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var property = FindFirst<PropertyDeclarationSyntax>(tree.GetRoot());
+            var propertySymbol = model.GetDeclaredSymbol(property)!;
+            Assert.AreEqual("Bar", Core.ToDiagnosticMessageName(propertySymbol));
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `ToDiagnosticMessageName` so nested types include their outer type in diagnostic output (e.g. `Outer<T>.Inner<U>` instead of `Inner<U>`), while still omitting namespace qualification.

## Changes

- **`Core.cs`**: Changed `SymbolDisplayTypeQualificationStyle` from `NameOnly` to `NameAndContainingTypes` in the diagnostic message format.
- **`CoreTest.cs`**: Added test coverage for all documented symbol kind conversions.
- **Analyzer tests**: Updated nested-type diagnostic expectations in `SMA0030`, `SMA0031`, and `SMA0040` tests to match the new format (e.g. `Outer.NestedStruct`).

## Expected output

| Symbol kind | Output |
|---|---|
| Local `int foo` | `foo` |
| Parameter `params int[] values` | `values` |
| Type `List<int>` | `List<int>` |
| Type `MyStruct<int>` | `MyStruct<int>` |
| Nested type `Outer<T>.Inner<U>` | `Outer<T>.Inner<U>` |
| Field `_field` | `_field` |
| Method `void Foo<T>(int value)` | `Foo<T>` |
| Property `float Bar` | `Bar` |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d1c0eb3-5401-4022-9855-0104ed27c0b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d1c0eb3-5401-4022-9855-0104ed27c0b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

