### PR TITLE
Add AGENTS.md for Cursor Cloud development setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ obj
 !icon-*.png
 
 *.md
+!AGENTS.md
 !CHANGELOG.md
 !README*.md
 !LICENSE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### What this repo is
+
+**SatorImaging.StaticMemberAnalyzer** is a Roslyn analyzer + code-fix NuGet package (C#). There is no web app or long-running server. End-to-end validation is **`dotnet test`** against in-memory C# snippets.
+
+### Prerequisites
+
+- **.NET SDK 10.x** (matches CI in `.github/workflows/test.yml`). Ubuntu: `sudo apt-get install -y dotnet-sdk-10.0`
+- **.NET 8 runtime/SDK** for the test project (`net8.0`): `sudo apt-get install -y dotnet-sdk-8.0 aspnetcore-runtime-8.0`
+- **NuGet egress**: `dotnet restore` needs HTTPS to `https://api.nuget.org/v3/index.json` (and package CDN hosts). Without it, restore fails with `NU1301` / SSL errors.
+
+### Critical MSBuild property
+
+Always pass **`-p:DontReferenceItself=true`** for the main solution and tests. Otherwise `Directory.Build.props` pulls the published `SatorImaging.StaticMemberAnalyzer` package from NuGet and creates a cyclic self-reference. The `debug/AnalyzerDebug.csproj` project is exempt and does not need this flag.
+
+### Standard commands (from repo root)
+
+| Task | Command |
+|------|---------|
+| Restore | `dotnet restore -p:DontReferenceItself=true` |
+| Build | `dotnet build StaticMemberAnalyzer.slnx -c Release -p:DontReferenceItself=true` |
+| Test (CI) | `dotnet test ./test -c Release --verbosity minimal -p:DontReferenceItself=true` |
+| Pack | `dotnet build src/packaging/SatorImaging.StaticMemberAnalyzer.Package.csproj -c Release -p:DontReferenceItself=true` |
+
+### Lint
+
+No separate lint script. Compile-time **Roslyn analyzer rules** (RS*, CS*) apply on build. Optional: `dotnet format` / `dotnet format analyzers` (see README). Repo `.editorconfig` sets some SMA00xx severities to `error`.
+
+### Manual playground (`debug/`)
+
+`debug/AnalyzerDebug.csproj` references the analyzer as a project and contains **intentionally broken** sample code. A full build often **fails** with SMA0001/SMA0002/etc. because those diagnostics are errors—this folder is for IDE/manual repro, not a green `dotnet run`. Prefer **`dotnet test`** for automated verification.
+
+### Optional (out of scope for typical agent work)
+
+- **Unity**: prebuilt DLLs under `Unity/`; manual Editor testing (see `Unity/README.md`).
+- **Visual Studio**: Roslyn hive debugging (`devenv /rootsuffix Roslyn`) on Windows.
+- **Docs**: `dotnet run -c Release ./eng/DocsGen.cs "./src/analysis/Resources.resx" "./RULES.md"`
+
+### Solution layout
+
+`StaticMemberAnalyzer.slnx` → `src/analysis`, `src/codefix`, `src/packaging`, `test/`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents how to build, test, and work on **StaticMemberAnalyzer** in Cursor Cloud VMs.

## Changes

- Add `AGENTS.md` with VM-specific prerequisites (`.NET SDK 10.x`, NuGet egress, `DontReferenceItself` flag) and standard commands aligned with CI.
- Allow `AGENTS.md` in `.gitignore` (repo ignores `*.md` by default).

## VM update script (configured separately)

```
dotnet restore -p:DontReferenceItself=true
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25f96615-a82a-42cb-853a-1edeb3b21c42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25f96615-a82a-42cb-853a-1edeb3b21c42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

